### PR TITLE
Fix card header title centering when panel size != 100%

### DIFF
--- a/res/layout/inner_base_header.xml
+++ b/res/layout/inner_base_header.xml
@@ -31,6 +31,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/card_header_inner_simple_title"
+        android:gravity="center_vertical"
         style="@style/card.header_simple_title"
         android:layout_centerVertical="true"/>
 


### PR DESCRIPTION
Fix vertical text centering if the panel size is set to a custom value.